### PR TITLE
fix(InversionOfControl): Skip return type annotation in autowired

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ from src.mock_entity.core.i_repository import IRepository
 
 class UseCase:
     @autowired
-    def __init__(self, repository: IRepository):
+    def __init__(self, repository: IRepository) -> None:
         self.repository = repository
 
     def my_use_case(self) -> str:

--- a/summer/inversion_of_control/dependencies.py
+++ b/summer/inversion_of_control/dependencies.py
@@ -18,6 +18,8 @@ def autowired(func: Callable) -> Callable:
     def wrapper(*args, **kwargs):
         func_annotation: Dict[str, Type[T]] = inspect.getfullargspec(func).annotations
         for key_param, key_type in func_annotation.items():
+            if key_param == 'return':
+                continue
             if key_type in services:
                 kwargs[key_param] = services_dict[get_context()][key_type]()
         func(*args, **kwargs)

--- a/tests/inversion_of_control/context/mock_entity/application/use_case.py
+++ b/tests/inversion_of_control/context/mock_entity/application/use_case.py
@@ -4,7 +4,7 @@ from tests.inversion_of_control.context.mock_entity.core.i_repository import IRe
 
 class UseCase:
     @autowired
-    def __init__(self, repository: IRepository):
+    def __init__(self, repository: IRepository) -> None:
         self.repository = repository
 
     def my_use_case(self) -> str:


### PR DESCRIPTION
# Changes
- Skipped *return* annotation in the `autowired` decorator
- Added return annotation to test class `UseCase.__init__`

# Motivation

According to [PEP-484](https://peps.python.org/pep-0484/#the-meaning-of-annotations) the `__init__` method should be typed with `-> None` but this causes an error in the dependency resolution, because it won't be able to find a service named *return*.

Some linters will enforce this annotation to be explicitly declared, so it's a necessary fix for some projects.
